### PR TITLE
feat: pack gen, unauthorized fixes + admin validation (v2.0.1-2.0.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,49 @@ Web application for generating randomized trading card booster packs for Oakland
 
 ## Recent Changes
 
+### February 28, 2026 - Pack Generation Bug Fixes (OAK-22, OAK-23, OAK-24)
+
+**Released as v2.0.1** — `src/data/changelog.json` updated; `2.0.0` entry marked `isCurrent: false`.
+
+**Motivation**: Three separate correctness bugs in `src/pages/index.tsx` were producing malformed packs, broken Excel exports, and a silent crash path in wildcard selection.
+
+**All changes are isolated to `src/pages/index.tsx`.**
+
+#### OAK-22 — Short-circuit `||` bug in base-category card loop
+
+**Root cause**: The condition `if (!addCard(col) || !addCard(col))` used JavaScript's short-circuit evaluation: when the first `addCard(col)` returned `false`, the second call was never made. Packs were only receiving one card per base category instead of two, producing 6-card packs instead of the expected 10.
+
+**Fix**: Replaced the single compound `if` with two separate `if (!addCard(col))` statements so both draws always execute regardless of the first result.
+
+**Why this matters**: Every subsequent feature (export, display, count validation) assumed 10-card packs. 6-card packs silently corrupted downstream behavior.
+
+#### OAK-23 — Export trigger state machine race condition
+
+**Root cause**: An `exportTrigger` boolean state was set to `true` inside `handleGenerateAndExport`, then watched by a `useEffect` that called `exportToExcel()`. React batches state updates, so there was no guarantee the effect fired at the right time relative to pack generation, and `isExporting` could be left as `true` permanently if an error occurred before the effect cleaned up.
+
+**Fix**:
+- Removed `exportTrigger` state and its `useEffect`.
+- `generatePacks()` now returns `any[][]` (the generated pack data) instead of writing only to component state.
+- `handleGenerateAndExport` calls `generatePacks()` directly, passes the return value to `exportToExcel()`, and wraps the call in `try/finally` to guarantee `isExporting` resets to `false` even on error.
+- Added an early return guard at the top of `handleGenerateAndExport` to prevent double-clicks while export is in progress.
+
+**Why this matters**: The old pattern left the UI in a permanently-disabled state on any export error. The new pattern is deterministic and handles errors cleanly.
+
+#### OAK-24 — Wildcard selection passing `undefined` to `addCard`
+
+**Root cause**: The wildcard slot selected a random category from `eligibleCategories`. When `eligibleCategories` was empty (e.g., all wildcard-eligible collections had no active cards), `eligibleCategories[randomIndex]` evaluated to `undefined`, which was passed directly to `addCard`. This caused a silent failure or runtime error with no warning.
+
+**Fix**: Wrapped the wildcard selection block in an `if (eligibleCategories.length > 0)` guard. When no eligible categories exist, the wildcard slot is skipped and a `console.warn` is emitted so the condition is visible during debugging.
+
+**Why this matters**: Passing `undefined` to `addCard` is a type violation that could produce unpredictable behavior depending on how downstream code handles it. The guard makes the empty-collection case explicit and observable.
+
+**Verification Results**:
+- Build: Successful
+- Lint: Clean
+- Breaking Changes: None — pack structure, UI, and Firebase integration are unchanged
+
+---
+
 ### December 7, 2024 - React 19 Upgrade & Security Hardening
 
 **Motivation**: Future-proofing and security improvements for long-term maintainability.
@@ -149,7 +192,7 @@ Each collection represents a card category:
 - 1 wildcard (random from any collection)
 - 1 Spoonbill card
 
-**Implementation**: See `src/utils/categories.ts` for generation logic
+**Implementation**: See `src/pages/index.tsx` (`generateBoosterPack`, `generatePacks`)
 
 ## Build & Deployment
 

--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -74,7 +74,7 @@ All three bugs are fully resolved in `src/pages/index.tsx`:
 | `CLAUDE.md` | Corrected generation logic file reference from `src/utils/categories.ts` to `src/pages/index.tsx` |
 | `AGENT.md` | Created (new file) |
 | `SESSIONS.md` | Created (new file) |
-| `/Users/albertshih/.claude/projects/-Users-albertshih-Developer-oz-card-randomizer/memory/MEMORY.md` | Created (new file) |
+| `MEMORY.md` (Claude memory directory) | Created (new file) |
 
 #### Next steps
 

--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -1,0 +1,83 @@
+# SESSIONS.md — Oakland Zoo Booster Pack Generator
+
+Session changelog. Append a new entry at the top of the Changelog section after each work session.
+
+---
+
+## Changelog
+
+### 2026-02-28 — OAK-26/32 + Go Back Button Fix (v2.0.2)
+
+**Branch**: `development`
+
+#### What was achieved
+
+All three changes are isolated to `src/components/unauthorized.tsx`.
+
+**OAK-26 — Fixed broken Sign-In button**
+
+The original code had `<Button>` wrapping `<SignInButton>`. Clerk's `SignInButton` uses `cloneElement` to inject `onClick` onto its child. When `<Button>` was the outer element, HeroUI's react-aria `onPress` intercepted pointer events before Clerk's injected handler fired, so clicking Sign In did nothing. Fix: inverted the nesting to `<SignInButton>` wrapping `<Button>`. This matches the established pattern in `navbar.tsx`. The erroneous `onPress={onClose}` was also removed from the Sign-In button.
+
+**OAK-32 — Removed close button and backdrop-click dismissal**
+
+Previously the unauthorized modal had a `×` button and could be dismissed by clicking the backdrop. Both paths called `onClose` but left the user at `/unauthorized` with a blank white screen and no route content. Fix: added `hideCloseButton` and `isDismissable={false}` to `<Modal>`. Both props must be set together — each controls a separate dismissal mechanism.
+
+**Go Back button — replaced `<Link>`-inside-`<Button>` anti-pattern**
+
+The "Go Back" button previously wrapped a `<Link>` inside a `<Button>`, rendering as `<a>` inside `<button>` — invalid HTML that breaks assistive-technology compatibility. Fix: imported `useNavigate` from `react-router-dom`, removed the `Link` import, and replaced the nested element with `onPress={() => { onClose(); navigate("/"); }}` on the `<Button>` directly.
+
+#### Released as
+
+**v2.0.2** — `src/data/changelog.json` updated; `2.0.1` entry marked `isCurrent: false`.
+
+#### Files changed this session
+
+| File | Change |
+|---|---|
+| `src/components/unauthorized.tsx` | All three fixes applied (only file with logic changes) |
+| `src/data/changelog.json` | v2.0.2 entry added; v2.0.1 marked `isCurrent: false` |
+
+#### Next steps
+
+- Open PR from `development` to `main` for v2.0.2
+- Manual smoke test: visit an admin-protected route while logged out, verify the modal opens, verify Sign In launches Clerk flow, verify Go Back navigates to `/` and closes modal, verify clicking outside or `×` does not dismiss the modal
+
+---
+
+### 2026-02-28 — OAK-22/23/24 Bug Fix Code Review + Documentation Init
+
+**Branch**: `development`
+
+#### What was achieved
+
+1. **Code review of OAK-22, OAK-23, OAK-24 fixes** in `src/pages/index.tsx`.
+
+2. **OAK-23 follow-up fix**: Identified that `setShowModal(false)` was placed after the `try/finally` block in `handleGenerateAndExport`, meaning it would not execute if `exportToExcel` threw. Moved it inside `finally` so the modal always closes regardless of success or error.
+
+3. **CLAUDE.md documentation fix**: The "Booster Pack Generation Logic" section incorrectly pointed to `src/utils/categories.ts` as the location of generation logic. Updated to correctly reference `src/pages/index.tsx` (`generateBoosterPack`, `generatePacks`).
+
+4. **Documentation init**: Created `AGENT.md` and `SESSIONS.md` in the project root for the first time. Created `MEMORY.md` in the Claude memory directory.
+
+#### Final state of OAK-22/23/24
+
+All three bugs are fully resolved in `src/pages/index.tsx`:
+
+- **OAK-22** (6-card packs): Two separate `if (!addCard(col))` calls replace the former short-circuit `||` compound condition. Both draws always execute.
+- **OAK-23** (export race condition + stuck UI): `exportTrigger` state and its `useEffect` removed. `generatePacks()` returns `any[][]`. `handleGenerateAndExport` calls `generatePacks()` directly, passes result to `exportToExcel()`, and uses `try/finally` with both `setIsExporting(false)` and `setShowModal(false)` inside `finally`.
+- **OAK-24** (undefined wildcard category): `if (eligibleCategories.length > 0)` guard wraps wildcard selection. Empty case emits `console.warn` instead of silently passing `undefined` to `addCard`.
+
+#### Files changed this session
+
+| File | Change |
+|---|---|
+| `src/pages/index.tsx` | Moved `setShowModal(false)` inside `finally` block in `handleGenerateAndExport` |
+| `CLAUDE.md` | Corrected generation logic file reference from `src/utils/categories.ts` to `src/pages/index.tsx` |
+| `AGENT.md` | Created (new file) |
+| `SESSIONS.md` | Created (new file) |
+| `/Users/albertshih/.claude/projects/-Users-albertshih-Developer-oz-card-randomizer/memory/MEMORY.md` | Created (new file) |
+
+#### Next steps
+
+- Open PR from `development` to `main` for the OAK-22/23/24 fixes
+- Manual smoke test: generate a pack and verify 10 cards appear; generate + export and verify modal closes on both success and error paths
+- Consider adding Vitest unit tests for `generateBoosterPack` to prevent regressions on pack structure

--- a/src/components/unauthorized.tsx
+++ b/src/components/unauthorized.tsx
@@ -9,9 +9,10 @@ import {
 } from "@heroui/modal";
 import { Button } from "@heroui/button";
 import { SignInButton } from "@clerk/clerk-react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 export default function Unauthorized() {
+    const navigate = useNavigate();
     const { isOpen, onOpen, onClose } = useDisclosure();
 
     const handleOpen = () => {
@@ -24,7 +25,7 @@ export default function Unauthorized() {
 
     return (
         <>
-            <Modal backdrop='blur' isOpen={isOpen} onClose={onClose}>
+            <Modal backdrop='blur' isOpen={isOpen} onClose={onClose} hideCloseButton isDismissable={false}>
                 <ModalContent>
                     {(onClose) => (
                         <>
@@ -35,12 +36,14 @@ export default function Unauthorized() {
                                 </p>
                             </ModalBody>
                             <ModalFooter>
-                                <Button color="danger" variant="light" onPress={onClose}>
-                                    <Link to="/">Go Back</Link>
+                                <Button color="danger" variant="light" onPress={() => { onClose(); navigate("/"); }}>
+                                    Go Back
                                 </Button>
-                                <Button color="success" onPress={onClose}>
-                                    <SignInButton></SignInButton>
-                                </Button>
+                                <SignInButton>
+                                    <Button color="success">
+                                        Sign In
+                                    </Button>
+                                </SignInButton>
                             </ModalFooter>
                         </>
                     )}

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,8 +1,24 @@
 [
   {
+    "version": "2.0.1",
+    "date": "February 28, 2026",
+    "isCurrent": true,
+    "sections": [
+      {
+        "title": "Bug Fixes",
+        "type": "fix",
+        "items": [
+          "Fixed pack generation producing only 6 cards instead of 10 — each base category now always contributes exactly 2 cards (OAK-22)",
+          "Fixed Excel export sometimes firing twice or not at all on rapid clicks — export now uses a direct call with a double-click guard (OAK-23)",
+          "Fixed wildcard slot crash when no eligible wildcard categories are configured — slot is now skipped gracefully with a warning (OAK-24)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "2.0.0",
     "date": "November 30, 2025",
-    "isCurrent": true,
+    "isCurrent": false,
     "sections": [
       {
         "title": "Global Design Revamp",

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -198,7 +198,7 @@
   },
   {
     "version": "1.0.0",
-    "date": "Febuary 2nd, 2025",
+    "date": "February 2nd, 2025",
     "isCurrent": false,
     "sections": [
       {

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,8 +1,24 @@
 [
   {
-    "version": "2.0.2",
+    "version": "2.0.3",
     "date": "February 28, 2026",
     "isCurrent": true,
+    "sections": [
+      {
+        "title": "Admin Form Validation",
+        "type": "feat",
+        "items": [
+          "Added input validation to the Edit Card and Categories admin forms — empty names, malformed card numbers, and special-character category IDs are now rejected before reaching Firestore (OAK-30)",
+          "Inline error messages appear next to each offending field for clear, immediate feedback",
+          "Category ID field is now read-only when editing an existing category to prevent orphaning cards in Firestore"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "2.0.2",
+    "date": "February 28, 2026",
+    "isCurrent": false,
     "sections": [
       {
         "title": "Bug Fixes",
@@ -112,7 +128,7 @@
     ]
   },
   {
-    "version": "1.2",
+    "version": "1.2.0",
     "date": "August 30, 2025",
     "isCurrent": false,
     "sections": [
@@ -148,7 +164,7 @@
     ]
   },
   {
-    "version": "1.1",
+    "version": "1.1.0",
     "date": "May 5, 2025",
     "isCurrent": false,
     "sections": [
@@ -181,7 +197,7 @@
     ]
   },
   {
-    "version": "1.0",
+    "version": "1.0.0",
     "date": "Febuary 2nd, 2025",
     "isCurrent": false,
     "sections": [

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,8 +1,24 @@
 [
   {
-    "version": "2.0.1",
+    "version": "2.0.2",
     "date": "February 28, 2026",
     "isCurrent": true,
+    "sections": [
+      {
+        "title": "Bug Fixes",
+        "type": "fix",
+        "items": [
+          "Fixed broken Sign-In button on the unauthorized page — Clerk's SignInButton now correctly wraps the HeroUI Button so click events are not intercepted by react-aria (OAK-26)",
+          "Removed the close (×) button and backdrop-click dismissal from the unauthorized modal — previously left users on a blank white screen with no way to navigate (OAK-32)",
+          "Replaced invalid <Link>-inside-<Button> pattern on the Go Back button with programmatic navigation via useNavigate — fixes assistive-technology compatibility and cross-browser click behavior"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "2.0.1",
+    "date": "February 28, 2026",
+    "isCurrent": false,
     "sections": [
       {
         "title": "Bug Fixes",
@@ -205,7 +221,7 @@
   },
   {
     "version": "Initial Release",
-    "date": "",
+    "date": "2024",
     "isCurrent": false,
     "sections": [
       {

--- a/src/pages/categories.tsx
+++ b/src/pages/categories.tsx
@@ -34,6 +34,7 @@ import DefaultLayout from "@/layouts/default";
 import Unauthorized from "@/components/unauthorized";
 import { event } from "@/lib/gtag";
 import { getCategories, clearCategoriesCache } from "@/utils/categories";
+import { validateCategoryForm, CategoryFormErrors } from "@/utils/validation";
 import { db, auth } from "@/lib/firebase";
 
 interface Category {
@@ -53,6 +54,7 @@ export default function CategoriesPage() {
     const { isOpen, onOpen, onClose } = useDisclosure();
     const [isCreating, setIsCreating] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
+    const [formErrors, setFormErrors] = useState<CategoryFormErrors>({});
 
     useEffect(() => {
         if (!isLoaded || !userId) return;
@@ -81,6 +83,7 @@ export default function CategoriesPage() {
         setNewCategoryName(category.displayName);
         setNewCategoryId(category.name);
         setIsCreating(false);
+        setFormErrors({});
         onOpen();
     };
 
@@ -89,11 +92,21 @@ export default function CategoriesPage() {
         setNewCategoryName("");
         setNewCategoryId("");
         setIsCreating(true);
+        setFormErrors({});
         onOpen();
     };
 
     const handleSave = async () => {
-        if (!newCategoryName.trim() || !newCategoryId.trim()) return;
+        const errors = validateCategoryForm({
+            displayName: newCategoryName,
+            categoryId: newCategoryId,
+        });
+        if (Object.keys(errors).length > 0) {
+            setFormErrors(errors);
+            return;
+        }
+        setFormErrors({});
+
         setIsSaving(true);
 
         try {
@@ -350,20 +363,33 @@ export default function CategoriesPage() {
                                 label="Display Name"
                                 placeholder="e.g., African Savannah"
                                 value={newCategoryName}
-                                onChange={(e) => setNewCategoryName(e.target.value)}
+                                onChange={(e) => {
+                                    setNewCategoryName(e.target.value);
+                                    if (formErrors.displayName)
+                                        setFormErrors((prev) => ({ ...prev, displayName: undefined }));
+                                }}
                                 variant="bordered"
                                 labelPlacement="outside"
                                 isRequired
+                                isInvalid={!!formErrors.displayName}
+                                errorMessage={formErrors.displayName}
                             />
                             <Input
                                 label="Category ID"
                                 placeholder="e.g., africansavanna"
                                 value={newCategoryId}
-                                onChange={(e) => setNewCategoryId(e.target.value)}
+                                onChange={(e) => {
+                                    setNewCategoryId(e.target.value);
+                                    if (formErrors.categoryId)
+                                        setFormErrors((prev) => ({ ...prev, categoryId: undefined }));
+                                }}
                                 description="Used internally - should be lowercase with no spaces"
                                 variant="bordered"
                                 labelPlacement="outside"
                                 isRequired
+                                isReadOnly={!isCreating}
+                                isInvalid={!!formErrors.categoryId}
+                                errorMessage={formErrors.categoryId}
                                 startContent={<span className="text-muted-foreground text-sm">#</span>}
                             />
                             {isCreating && (

--- a/src/pages/editcard.tsx
+++ b/src/pages/editcard.tsx
@@ -28,6 +28,7 @@ import Unauthorized from "@/components/unauthorized";
 import { event } from "@/lib/gtag";
 import { getCategories, categoriesToLegacyFormat } from "@/utils/categories";
 import { db, auth } from "@/lib/firebase";
+import { validateCardForm, CardFormErrors } from "@/utils/validation";
 import { Save, Trash2, X } from "lucide-react";
 
 interface Card {
@@ -47,6 +48,7 @@ export default function EditCardPage() {
   const [selectedCard, setSelectedCard] = useState<Card | null>(null);
   const [collections, setCollections] = useState<{ id: string, name: string }[]>([]);
   const [isSaving, setIsSaving] = useState(false);
+  const [formErrors, setFormErrors] = useState<CardFormErrors>({});
 
   // Parse query parameters (e.g. ?cardId=...&collection=... or ?new=true)
   const searchParams = new URLSearchParams(location.search);
@@ -104,6 +106,14 @@ export default function EditCardPage() {
 
   const handleSave = async (updatedCard: Card | null) => {
     if (!updatedCard) return;
+
+    const errors = validateCardForm(updatedCard);
+    if (Object.keys(errors).length > 0) {
+      setFormErrors(errors);
+      return;
+    }
+    setFormErrors({});
+
     setIsSaving(true);
     try {
       // Ensure we're authenticated with Firebase before any write
@@ -186,6 +196,7 @@ export default function EditCardPage() {
       navigate("/edit");
     } catch (err) {
       console.error("Error deleting card:", err);
+    } finally {
       setIsSaving(false);
     }
   };
@@ -241,27 +252,34 @@ export default function EditCardPage() {
                   label="Card Name"
                   placeholder="e.g. African Lion"
                   value={selectedCard?.name || ""}
-                  onChange={(e) =>
+                  onChange={(e) => {
                     setSelectedCard(
                       selectedCard ? { ...selectedCard, name: e.target.value } : null
-                    )
-                  }
+                    );
+                    if (formErrors.name) setFormErrors((prev) => ({ ...prev, name: undefined }));
+                  }}
                   variant="bordered"
                   labelPlacement="outside"
                   isRequired
+                  isInvalid={!!formErrors.name}
+                  errorMessage={formErrors.name}
                 />
                 <Input
                   label="Card Number"
                   placeholder="e.g. 42"
                   value={selectedCard?.number || ""}
-                  onChange={(e) =>
+                  onChange={(e) => {
                     setSelectedCard(
                       selectedCard ? { ...selectedCard, number: e.target.value } : null
-                    )
-                  }
+                    );
+                    if (formErrors.number)
+                      setFormErrors((prev) => ({ ...prev, number: undefined }));
+                  }}
                   variant="bordered"
                   labelPlacement="outside"
                   isRequired
+                  isInvalid={!!formErrors.number}
+                  errorMessage={formErrors.number}
                 />
               </div>
 
@@ -269,14 +287,18 @@ export default function EditCardPage() {
                 label="Collection Category"
                 placeholder="Select a category"
                 selectedKeys={selectedCard?.collection ? [selectedCard.collection] : []}
-                onChange={(e) =>
+                onChange={(e) => {
                   setSelectedCard(
                     selectedCard ? { ...selectedCard, collection: e.target.value } : null
-                  )
-                }
+                  );
+                  if (formErrors.collection)
+                    setFormErrors((prev) => ({ ...prev, collection: undefined }));
+                }}
                 variant="bordered"
                 labelPlacement="outside"
                 isRequired
+                isInvalid={!!formErrors.collection}
+                errorMessage={formErrors.collection}
               >
                 {collections.map((col) => (
                   <SelectItem key={col.id}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -56,7 +56,6 @@ export default function IndexPage() {
     const [showModal, setShowModal] = useState(false);
     const [numPacks, setNumPacks] = useState(1);
     const [isExporting, setIsExporting] = useState(false);
-    const [exportTrigger, setExportTrigger] = useState(false);
     const [collections, setCollections] = useState<LegacyCollection[]>([]);
 
     const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set([]));
@@ -101,15 +100,6 @@ export default function IndexPage() {
         fetchData();
     }, []);
 
-    // Export when packs generated (spreadsheet)
-    useEffect(() => {
-        if (exportTrigger && boosterPacks.length > 0) {
-            exportToExcel(boosterPacks);
-            setIsExporting(false);  // Stop loading after export
-            setExportTrigger(false); // Reset trigger
-        }
-    }, [boosterPacks, exportTrigger]);
-
     // open modal function
     const handleOpenModal = () => {
         event({
@@ -147,8 +137,11 @@ export default function IndexPage() {
 
         // First 8 cards: two from each of the specified 4 categories (order matters)
         for (const col of BASE_CATEGORIES) {
-            if (!addCard(col) || !addCard(col)) {
-                console.warn(`Not enough cards in ${col} collection`);
+            if (!addCard(col)) {
+                console.warn(`Not enough cards in ${col} collection (card 1)`);
+            }
+            if (!addCard(col)) {
+                console.warn(`Not enough cards in ${col} collection (card 2)`);
             }
         }
 
@@ -159,17 +152,20 @@ export default function IndexPage() {
                 return collection?.isWildcardEligible && Array.isArray(cardsData[id]) && cardsData[id].length > 0;
             });
 
-        let randomCollection: string | undefined;
-        let attempts = 0;
-        const maxAttempts = Math.max(10, eligibleCategories.length * 2);
-        while (attempts < maxAttempts) {
-            randomCollection = eligibleCategories[Math.floor(Math.random() * eligibleCategories.length)];
-            if (addCard(randomCollection)) break;
-            attempts++;
-        }
-
-        if (attempts >= maxAttempts) {
-            console.warn("Failed to add a card from a random collection after 10 attempts");
+        if (eligibleCategories.length > 0) {
+            let randomCollection: string | undefined;
+            let attempts = 0;
+            const maxAttempts = Math.max(10, eligibleCategories.length * 2);
+            while (attempts < maxAttempts) {
+                randomCollection = eligibleCategories[Math.floor(Math.random() * eligibleCategories.length)];
+                if (addCard(randomCollection)) break;
+                attempts++;
+            }
+            if (attempts >= maxAttempts) {
+                console.warn("Failed to add a card from a random collection after 10 attempts");
+            }
+        } else {
+            console.warn("No wildcard-eligible categories found; wildcard slot skipped");
         }
 
         if (!addCard('spoonbill')) {
@@ -188,7 +184,8 @@ export default function IndexPage() {
     };
 
     // MORE PACKS (multiple packs)
-    const generatePacks = (count: number) => {
+    const generatePacks = (count: number): any[][] => {
+        let newPacks: any[][] = [];
         try {
             event({
                 action: 'generate',
@@ -211,7 +208,7 @@ export default function IndexPage() {
                 });
             }
 
-            const newPacks = [];
+            newPacks = [];
             for (let i = 0; i < count; i++) {
                 newPacks.push(generateBoosterPack());
             }
@@ -229,20 +226,28 @@ export default function IndexPage() {
             });
             setError("Failed to generate booster packs. Please try again.");
         }
+        return newPacks;
     };
 
     // Function to generate packs and export
     const handleGenerateAndExport = () => {
+        if (isExporting) return; // prevent double-click
         event({
             action: 'export',
             category: 'spreadsheet',
             label: 'generate_and_export',
             value: numPacks
         });
-        setIsExporting(true); // Start loading state
-        generatePacks(numPacks);
-        setExportTrigger(true); // Signal to trigger export when packs are ready
-        setShowModal(false); // Close the modal
+        setIsExporting(true);
+        try {
+            const packs = generatePacks(numPacks);
+            if (packs.length > 0) {
+                exportToExcel(packs);
+            }
+        } finally {
+            setIsExporting(false);
+            setShowModal(false);
+        }
     };
 
     // Function to export booster packs to Excel

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,70 @@
+export interface CardFormErrors {
+  name?: string;
+  number?: string;
+  collection?: string;
+  _form?: string;
+}
+
+interface CardFormData {
+  name: string;
+  number: string;
+  collection: string;
+  active: boolean;
+}
+
+export const validateCardForm = (card: CardFormData): CardFormErrors => {
+  const errors: CardFormErrors = {};
+
+  if (!card.name.trim()) {
+    errors.name = "Card name is required.";
+  }
+
+  if (!card.number.trim()) {
+    errors.number = "Card number is required.";
+  } else if (!/^\d+$/.test(card.number.trim())) {
+    errors.number = "Card number must be a positive integer (e.g., 42).";
+  }
+
+  if (!card.collection) {
+    errors.collection = "Please select a collection.";
+  }
+
+  if (typeof card.active !== "boolean") {
+    console.error(
+      "validateCardForm: active field is not a boolean. Write blocked.",
+    );
+    errors._form = "blocked";
+  }
+
+  return errors;
+};
+
+export interface CategoryFormErrors {
+  displayName?: string;
+  categoryId?: string;
+}
+
+interface CategoryFormData {
+  displayName: string;
+  categoryId: string;
+}
+
+export const validateCategoryForm = (
+  data: CategoryFormData,
+): CategoryFormErrors => {
+  const errors: CategoryFormErrors = {};
+
+  if (!data.displayName.trim()) {
+    errors.displayName = "Display name is required.";
+  }
+
+  const normalizedId = data.categoryId.toLowerCase().replace(/\s+/g, "");
+
+  if (!normalizedId) {
+    errors.categoryId = "Category ID is required.";
+  } else if (!/^[a-z0-9]+$/.test(normalizedId)) {
+    errors.categoryId = "Category ID can only contain letters and numbers.";
+  }
+
+  return errors;
+};

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -22,7 +22,7 @@ export const validateCardForm = (card: CardFormData): CardFormErrors => {
   if (!card.number.trim()) {
     errors.number = "Card number is required.";
   } else if (!/^\d+$/.test(card.number.trim())) {
-    errors.number = "Card number must be a positive integer (e.g., 42).";
+    errors.number = "Card number must be a non-negative integer (e.g., 0 or 42).";
   }
 
   if (!card.collection) {


### PR DESCRIPTION
## Summary
   - Fix three pack generation correctness bugs (OAK-22, OAK-23, OAK-24): packs now reliably produce 10 cards, Excel export is deterministic with proper error
   recovery, and wildcard selection is guarded against empty collections
   - Fix unauthorized page UX bugs (OAK-26, OAK-32): Clerk sign-in button works correctly, modal cannot be dismissed to a blank screen, and Go Back navigation is
   valid HTML
   - Add shared form validation utility and inline error messaging for admin card/category forms (OAK-30, OAK-33, OAK-34, OAK-35)

   ## Changes by Issue

   ### Pack Generation (v2.0.1)
   - **OAK-22** — Fix short-circuit `||` in base-category loop; packs now produce 10 cards as intended
   - **OAK-23** — Remove `exportTrigger` state machine; `generatePacks()` returns data directly, `handleGenerateAndExport` uses `try/finally` for deterministic
   cleanup
   - **OAK-24** — Guard wildcard slot against empty `eligibleCategories` array to prevent `undefined` reaching `addCard`

   ### Unauthorized Page (v2.0.2)
   - **OAK-26** — Invert `SignInButton`/`Button` nesting so Clerk's `onClick` fires before react-aria intercepts
   - **OAK-32** — Add `hideCloseButton` + `isDismissable={false}` to prevent modal dismissal to blank screen
   - Fix `<Link>`-inside-`<Button>` invalid HTML; replace with `useNavigate()` + `onPress`

   ### Admin Validation (v2.0.3)
   - **OAK-30** — New `src/utils/validation.ts`: `validateCardForm` + `validateCategoryForm`; block Firestore writes on invalid input
   - **OAK-33** — Wire `isInvalid`/`errorMessage` on all admin form inputs; errors clear on field change
   - **OAK-34** — Category ID is read-only when editing existing categories (prevents orphaning card documents)
   - **OAK-35** — `finally` block in `handleDelete` ensures `setIsSaving(false)` always resets